### PR TITLE
Signals kill children, and JAR is run in bg

### DIFF
--- a/bake/java/bake/tool/java/ExecutableJar.java
+++ b/bake/java/bake/tool/java/ExecutableJar.java
@@ -26,11 +26,13 @@ abstract class ExecutableJar {
       + "set -u\n" // Require variables to be set.
       + "set -e\n" // Exit on error.
       + "tempfile=`mktemp -t bake.XXXXXXXXXX`\n"
-      + "trap \"rm -f $tempfile; exit\" INT TERM EXIT\n"
+      + "trap \"rm -f $tempfile; exit\" EXIT\n"
+      + "trap \"rm -f $tempfile; kill 0; false; exit\" INT TERM\n"
       + "cat <<\"EOF\" | openssl enc -d -base64 > $tempfile\n";
 
   private static final String SCRIPT_SUFFIX = "EOF\n"
-      + "java $VM_ARGS -jar $tempfile $ARGS \"$@\"\n";
+      + "java $VM_ARGS -jar $tempfile $ARGS \"$@\" &\n"
+      + "wait\n";
 
   final JavaHandler handler;
 


### PR DESCRIPTION
When sh gets INT or TERM signals, we want to send SIGTERM to the
java process.
Experimentation shows that bash only honors signal handlers if the
java process is backgrounded.

Quirks: sometimes this script's `kill 0` kills the script itself,
which causes it to exit with status 143 and print 'Terminated'
to STDERR, but other times it reaches the end of the signal handler
first, which exits with status 1.
